### PR TITLE
Fix MongoDB plugin early exit on secondary nodes

### DIFF
--- a/agents/plugins/mk_mongodb.py
+++ b/agents/plugins/mk_mongodb.py
@@ -982,7 +982,9 @@ def main(argv=None):
         # this is detected here
         if "primary" in repl_info and not repl_info.get("primary"):
             _write_section_replica(None)
-        return
+        # Fixed: Only return if there is truly no primary
+        if "primary" in repl_info and not repl_info.get("primary"):
+            return
 
     piggyhost = repl_info.get("setName") if repl_info else None
     if piggyhost:


### PR DESCRIPTION
The plugin was unconditionally exiting when connected to secondary MongoDB nodes, causing monitoring failures with Azure Private Endpoints and load balancers that route to secondary nodes.

Fix: Only exit if there is truly no primary node available.


# Expected vs Observed Behavior
Expected: Plugin should generate piggybacking data for MongoDB monitoring services even when connected to secondary nodes, as long as a primary exists in the replica set.

Observed: Plugin exits early with unconditional `return` statement when connected to secondary nodes, preventing any piggybacking data generation and causing complete monitoring failure.

# Operating System
Ubuntu 20.04/22.04 LTS (CheckMK agent host)
CheckMK version: 2.4.0p7.cce

# Local Setup
- MongoDB Atlas cluster behind Azure Private Endpoint
- Private Endpoint load balancer (managed by mongo) routing connections to secondary MongoDB nodes
- CheckMK agent with mk_mongodb.py plugin for piggybacking

# Reproduce (routing is managed by Mongo - so its only reproducable if you are being routed to a secondary node)
1. Set up MongoDB Atlas cluster with Azure Private Endpoint
2. Configure CheckMK mk_mongodb.py plugin to connect via Private Endpoint
3. MongoDB Atlas Load Blancer which routes to secondary MongoDB node
4. Plugin exits early on line 985 without generating piggybacking data
5. All MongoDB services disappear from the target dummy host

# Root Cause
Line 985 contains `return` without checking if a primary exists in the replica set.

#Solution
Replace unconditional return with conditional logic that only exits if no primary is available.

# Changes
- Modified line 985 in `agents/plugins/mk_mongodb.py`
- Added condition to check for primary existence before returning
- Allows monitoring to continue from secondary nodes when primary is available

-Before (Line 985) : 
        return
        
-After (Line 985-987: 
        # Fixed: Only return if there is truly no primary
        if "primary" in repl_info and not repl_info.get("primary"):
            return

# Testing
- Tested with MongoDB Atlas behind Azure Private Endpoint
- Verified piggybacking data generation from secondary nodes
- Confirmed all services appear correctly on target hosts

# Impact
Fixes MongoDB Atlas monitoring for users with:
- Azure Private Endpoints
- MongoDB Atlas Load balancers routing to secondary nodes
- Any setup where connection lands on secondary first
